### PR TITLE
fix(ports): update settings of favonia/cloudflare-ddns

### DIFF
--- a/ports/services/cloudflare_ddns/README.md
+++ b/ports/services/cloudflare_ddns/README.md
@@ -11,17 +11,13 @@ services:
     container_name: cloudflare_ddns
     network_mode: host
     restart: always
-    cap_add:
-      - SETUID
-      - SETGID
+    user: "1000:1000"
     cap_drop:
       - all
     read_only: true
     security_opt:
       - no-new-privileges:true
     environment:
-      - PUID=1000
-      - PGID=1000
       - CF_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
       - IP6_PROVIDER=none
       - DOMAINS=your-domain.tld,*.your-domain.tld,mc.your-domain.tld

--- a/ports/services/cloudflare_ddns/docker-compose.yml
+++ b/ports/services/cloudflare_ddns/docker-compose.yml
@@ -4,17 +4,13 @@ services:
     container_name: cloudflare_ddns
     network_mode: host
     restart: always
-    cap_add:
-      - SETUID
-      - SETGID
+    user: "1000:1000"
     cap_drop:
       - all
     read_only: true
     security_opt:
       - no-new-privileges:true
     environment:
-      - PUID=1000
-      - PGID=1000
       - CF_API_TOKEN=YOUR_CLOUDFLARE_API_TOKEN
       - IP6_PROVIDER=none
       - DOMAINS=your-domain.tld,*.your-domain.tld,mc.your-domain.tld


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.